### PR TITLE
bugfix/heroku_deployment

### DIFF
--- a/syllabustool/settings.py
+++ b/syllabustool/settings.py
@@ -146,10 +146,12 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
 
-
+# Heroku
+# import os
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
-
-
+import django_heroku
+django_heroku.settings(locals())
 
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')


### PR DESCRIPTION
Someone deleted heroku info in settings.py (or committed without pulling) and broke deployment (doesn't recognize Heroku as a base URL).  This should hopefully fix it.